### PR TITLE
Add CI workflow to run vp check on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+      - run: vp check

--- a/src/app/resume/txt/markdoc-components.tsx
+++ b/src/app/resume/txt/markdoc-components.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export const Intro = ({
   children,
-  className,
+  className: _className,
 }: {
   children?: React.ReactNode;
   className?: string;


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `vp check` (format + lint + types) on PRs to `main` and pushes to `main`
- Uses `voidzero-dev/setup-vp@v1` with caching per CLAUDE.md guidance
- Cleans up the one pre-existing lint warning so `vp check` runs clean

## Branch protection
After merge, mark `check` as a required status check on `main` (Settings → Branches → main → Require status checks). I'll attempt this via `gh api` once the workflow has run at least once so the check is registered.

## Test plan
- [x] `vp check` passes locally (0 errors, 0 warnings)
- [ ] CI run on this PR succeeds
- [ ] After merge: `check` is enforced as a required status check on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)