### PR TITLE
Add Markdown export endpoint for resume

### DIFF
--- a/src/lib/resume/md-components.ts
+++ b/src/lib/resume/md-components.ts
@@ -1,0 +1,84 @@
+// src/lib/resume/md-components.ts
+import { type TextComponent, isTag } from "./render-text";
+import type { RenderableTreeNode } from "@markdoc/markdoc";
+
+export const Intro: TextComponent = (_attrs, children, render) => {
+  const text = render(children).trim();
+  return `\n\n${text}\n\n`;
+};
+
+export const Stint: TextComponent<{
+  title: string;
+  start?: string;
+  end?: string;
+  location: string;
+  organization: string;
+  url?: string;
+}> = (attrs, children, render) => {
+  const title = attrs.title.trim();
+  const dates =
+    attrs.start && attrs.end
+      ? `${attrs.start.trim()} – ${attrs.end.trim()}`
+      : (attrs.start ?? attrs.end ?? "").trim();
+  const heading = `### ${title}${dates ? ` — ${dates}` : ""}`;
+  const org = attrs.organization.trim();
+  const orgLink = attrs.url?.trim() ? `[${org}](${attrs.url.trim()})` : org;
+  const location = attrs.location?.trim();
+  const orgLine = location ? `${orgLink}, ${location}` : orgLink;
+  const body = render(children).trim();
+  return `\n\n${heading}\n\n${orgLine}\n\n${body ? `${body}\n\n` : ""}`;
+};
+
+const isNamed = (node: RenderableTreeNode, name: string) => isTag(node) && node.name === name;
+
+const isH4 = (node: RenderableTreeNode) =>
+  isNamed(node, "h4") ||
+  (isNamed(node, "Heading") && (node as { attributes: { level?: number } }).attributes.level === 4);
+
+export const SkillsSection: TextComponent = (_attrs, children, render) => {
+  const out: string[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const next = children[i + 1];
+    if (isH4(child) && next && isNamed(next, "List") && isTag(next)) {
+      const heading = render([child])
+        .trim()
+        .replace(/^#+\s*/, "");
+      const items = next.children
+        .filter((c) => isNamed(c, "li") && isTag(c))
+        .map((li) => render((li as { children: RenderableTreeNode[] }).children).trim());
+      out.push(`**${heading}:** ${items.join(", ")}\n\n`);
+      i++;
+    } else {
+      out.push(render([child]));
+    }
+  }
+  return out.join("");
+};
+
+export const List: TextComponent<{ listType?: "bullet" | "compact" }> = (attrs, children, render) =>
+  attrs.listType === "compact" ? `${render(children)}\n\n` : `${render(children)}\n`;
+
+export const li: TextComponent<{
+  listType?: "bullet" | "compact";
+  ordered?: boolean;
+  index?: number;
+  last?: boolean;
+}> = (attrs, children, render) => {
+  const text = render(children).trim().replace(/\s+/g, " ");
+  if (attrs.listType === "compact") {
+    return attrs.last ? text : `${text}, `;
+  }
+  if (attrs.ordered) {
+    return `${attrs.index}. ${text}\n`;
+  }
+  return `- ${text}\n`;
+};
+
+export const PageBreak: TextComponent = () => "";
+
+export const Heading: TextComponent<{ level: number }> = (attrs, children, render) => {
+  const text = render(children).trim();
+  const prefix = "#".repeat(attrs.level);
+  return `\n\n${prefix} ${text}\n\n`;
+};

--- a/src/pages/resume/md.ts
+++ b/src/pages/resume/md.ts
@@ -1,0 +1,39 @@
+// src/pages/resume/md.ts
+import * as components from "@/lib/resume/md-components";
+import { type TextComponents, renderText } from "@/lib/resume/render-text";
+import Markdoc from "@markdoc/markdoc";
+import { baseConfig } from "@/lib/resume/markdoc-base";
+import { getEntry } from "astro:content";
+
+export const prerender = true;
+
+export async function GET() {
+  const entry = await getEntry("resume", "resume");
+  if (!entry) {
+    throw new Error("resume entry not found");
+  }
+  const raw = entry.body ?? "";
+  if (!raw) {
+    throw new Error("resume entry has empty body — check the glob loader");
+  }
+  const ast = Markdoc.parse(raw);
+  const tree = Markdoc.transform(ast, {
+    ...baseConfig,
+    nodes: {
+      ...baseConfig.nodes,
+      heading: {
+        render: "Heading",
+        attributes: { level: { type: Number, required: true } },
+      },
+    },
+    variables: { frontmatter: entry.data },
+  });
+  const { name, github, email } = entry.data;
+  const githubUsername = github.replace(/^https?:\/\/(www\.)?github\.com\//, "").replace(/\/$/, "");
+  const header = `# ${name}\n\n- [${githubUsername}@github](${github})\n- [${email}](mailto:${email})`;
+  const body = renderText(tree, { components: components as unknown as TextComponents });
+  const content = `${(header + body).trim()}\n`;
+  return new Response(content, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/src/pages/resume/md.ts
+++ b/src/pages/resume/md.ts
@@ -4,6 +4,7 @@ import { type TextComponents, renderText } from "@/lib/resume/render-text";
 import Markdoc from "@markdoc/markdoc";
 import { baseConfig } from "@/lib/resume/markdoc-base";
 import { getEntry } from "astro:content";
+import prettier from "prettier";
 
 export const prerender = true;
 
@@ -32,7 +33,7 @@ export async function GET() {
   const githubUsername = github.replace(/^https?:\/\/(www\.)?github\.com\//, "").replace(/\/$/, "");
   const header = `# ${name}\n\n- [${githubUsername}@github](${github})\n- [${email}](mailto:${email})`;
   const body = renderText(tree, { components: components as unknown as TextComponents });
-  const content = `${(header + body).trim()}\n`;
+  const content = await prettier.format(`${(header + body).trim()}\n`, { parser: "markdown" });
   return new Response(content, {
     headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });


### PR DESCRIPTION
## Summary
This PR adds the ability to export the resume as a Markdown file by creating a new API endpoint and supporting components for rendering resume content to plain text Markdown format.

## Key Changes
- **New file: `src/lib/resume/md-components.ts`** - Implements Markdown rendering components for resume elements:
  - `Intro` - Renders introductory text with spacing
  - `Stint` - Renders work experience entries with title, dates, organization, location, and description
  - `SkillsSection` - Transforms nested heading/list structures into inline skill categories (e.g., "**Skills:** item1, item2")
  - `List` and `li` - Handle both bullet and compact list formatting
  - `Heading` - Renders Markdown headings with proper level support
  - `PageBreak` - Placeholder for page breaks (renders as empty)

- **New file: `src/pages/resume/md.ts`** - Creates a prerendered GET endpoint that:
  - Fetches the resume content from the content collection
  - Parses and transforms it using Markdoc with custom configuration
  - Renders the AST to plain text Markdown using the new components
  - Includes a formatted header with name, GitHub link, and email
  - Returns the content with proper `text/markdown` content type

## Notable Implementation Details
- The `SkillsSection` component intelligently pairs H4 headings with following List elements to create compact skill category formatting
- List items support both ordered/unordered and compact/expanded formats
- The endpoint is prerendered for static generation
- Proper error handling for missing or empty resume entries

https://claude.ai/code/session_016RE4gVYqKTjCmRjdCSLaQr